### PR TITLE
Encode IEND chunk using the IEND encoder

### DIFF
--- a/lib/imagineer/image/png/chunk.ex
+++ b/lib/imagineer/image/png/chunk.ex
@@ -50,7 +50,7 @@ defmodule Imagineer.Image.PNG.Chunk do
   encode_chunk @ihdr_header, with: Encoders.Header
   encode_chunk @plte_header, with: Encoders.Palette
   encode_chunk @idat_header, with: Encoders.DataContent
-  encode_chunk @iend_header, with: Encoders.DataContent
+  encode_chunk @iend_header, with: Encoders.End
 
   encode_chunk @trns_header, with: Encoders.Transparency
   encode_chunk @bkgd_header, with: Encoders.Background


### PR DESCRIPTION
This was causing a bug whereby the IEND chunk misreported its length, leading to invalid PNGs.