### PR TITLE
Avoid Enum.join when working with raw binaries

### DIFF
--- a/lib/imagineer/image/png/compression/zlib.ex
+++ b/lib/imagineer/image/png/compression/zlib.ex
@@ -24,7 +24,7 @@ defmodule Imagineer.Image.PNG.Compression.Zlib do
   def decompress(%PNG{data_content: compressed_data}) do
     zlib_stream = :zlib.open()
     :ok = :zlib.inflateInit(zlib_stream)
-    decompressed_data = Enum.join(:zlib.inflate(zlib_stream, compressed_data), "")
+    decompressed_data = IO.iodata_to_binary(:zlib.inflate(zlib_stream, compressed_data))
     :ok = :zlib.inflateEnd(zlib_stream)
     :ok = :zlib.close(zlib_stream)
     decompressed_data
@@ -39,6 +39,6 @@ defmodule Imagineer.Image.PNG.Compression.Zlib do
     compressed_data = :zlib.deflate(zlib_stream, decompressed_data, :finish)
     :ok = :zlib.deflateEnd(zlib_stream)
     :ok = :zlib.close(zlib_stream)
-    Enum.join compressed_data
+    :binary.list_to_bin(compressed_data)
   end
 end


### PR DESCRIPTION
In Elixir 1.6 two tests fail -- this is because Enum.join is converting items to UTF-8 strings.

This pull request uses iodata_to_binary and list_to_bin instead of Enum.join when calling zlib since we are working with raw binary data.