### PR TITLE
Remove warnings by adding parentheses

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,10 +6,10 @@ defmodule Imagineer.Mixfile do
       app: :imagineer,
       version: "0.3.0",
       elixir: "~> 1.4",
-      deps: deps,
+      deps: deps(),
       source_url: "https://github.com/SenecaSystems/imagineer",
-      description: description,
-      package: package
+      description: description(),
+      package: package()
     ]
   end
 
@@ -32,8 +32,8 @@ defmodule Imagineer.Mixfile do
 
   defp package do
   [
-    maintainers: maintainers,
-    links: links,
+    maintainers: maintainers(),
+    links: links(),
     licenses: ["MIT"]
   ]
   end


### PR DESCRIPTION
Elixir is giving me some warning because this functions are not being called with `()` 